### PR TITLE
Make upload to Sonatype less flaky

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,9 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 
+# Increase timeout when pushing to Sonatype (otherwise we get timeouts)s
+systemProp.org.gradle.internal.http.socketTimeout=120000
+
 
 ##### Publishing
 # Publish to Maven Central

--- a/publish_local.sh
+++ b/publish_local.sh
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-./gradlew publishToMavenLocal
+# We manually run assemble & dokka before uploadArchives. If we only run uploadArchives,
+# the assemble and dokka tasks are run interleaved on each module, which can cause
+# connection timeouts to Sonatype (since we need to wait for assemble+dokka to finish).
+# By front-loading the assemble+dokka tasks, the upload is much quicker.
+./gradlew assembleRelease dokkaHtml publishToMavenLocal --no-daemon --no-parallel

--- a/publish_release.sh
+++ b/publish_release.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-./gradlew publish --no-daemon --no-parallel
-./gradlew closeAndReleaseRepository
+# We manually run assemble & dokka before uploadArchives. If we only run uploadArchives,
+# the assemble and dokka tasks are run interleaved on each module, which can cause
+# connection timeouts to Sonatype (since we need to wait for assemble+dokka to finish).
+# By front-loading the assemble+dokka tasks, the upload is much quicker.
+./gradlew assembleRelease dokkaHtml publish closeAndReleaseRepository --no-daemon --no-parallel
 


### PR DESCRIPTION
There is a bug that leads to flaky uploads to SonaType [[Read more](https://github.com/vanniktech/gradle-maven-publish-plugin/issues/170)]

