### PR TITLE
Removed tick sound when playing

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
 [*.{kt, kts}]
-indent_size = 2
+indent_size = 4
 insert_final_newline = true
 max_line_length = 120
 

--- a/app/src/main/java/com/github/nisrulz/samplezentone/MainActivity.kt
+++ b/app/src/main/java/com/github/nisrulz/samplezentone/MainActivity.kt
@@ -63,12 +63,12 @@ class MainActivity : AppCompatActivity() {
                     editTextFreq.setText(progress.toString())
                 }
 
-                override fun onStartTrackingTouch(seekBar: SeekBar) {
-                    stopPlayingAudio(binding)
+                override fun onStartTrackingTouch(seekBar: SeekBar?) {
+                    // Nothing to do here.
                 }
 
                 override fun onStopTrackingTouch(seekBar: SeekBar) {
-                    handlePlayPauseState(binding)
+                    zenTone.setFrequency(editTextFreq.text.toString().toFloat())
                 }
             })
         }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/ZenTone.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/ZenTone.kt
@@ -40,6 +40,8 @@ class ZenTone(
 
     /** Boolean flag to check if ZenTone is playing tone */
     var isPlaying = false
+    /** Current frequency in use by ZenTone.*/
+    private var frequency:Float = 0.0F
 
     /**
      * Start playing the tone as per passed config
@@ -54,8 +56,7 @@ class ZenTone(
         waveByteArrayGenerator: WaveByteArrayGenerator = SineWaveGenerator
     ) {
         if (!isPlaying && volume > 0) {
-            val freqOfTone = sanitizeFrequencyValue(frequency)
-            val audioData = waveByteArrayGenerator.generate(freqOfTone)
+            this.setFrequency(frequency)
 
             audioTrack.apply {
                 if (state != AudioTrack.STATE_INITIALIZED) cancel() // cancel all jobs
@@ -67,6 +68,7 @@ class ZenTone(
 
                 launch {
                     while (isPlaying) {
+                        val audioData = waveByteArrayGenerator.generate(this@ZenTone.frequency)
                         write(audioData, 0, audioData.size)
                     }
 
@@ -83,6 +85,10 @@ class ZenTone(
         if (isPlaying) {
             isPlaying = false
         }
+    }
+
+    fun setFrequency(frequency: Float) {
+        this.frequency = sanitizeFrequencyValue(frequency)
     }
 
     /** Release and free up resources held by ZenTone */

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/AngleBaseWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/AngleBaseWaveGenerator.kt
@@ -1,0 +1,43 @@
+package com.github.nisrulz.zentone.wave_generators
+
+import kotlin.math.PI
+
+/**
+ * Base class for angle based wave generators. Generates a continuesly changing angle for the
+ * the wave generators to use. The angle wraps around 2*Pi.
+ */
+abstract class AngleBaseWaveGenerator : WaveByteArrayGenerator {
+
+    private var angle:Double = 0.0
+    private var angleStep:Double = 0.0
+
+    /**
+     * Reset the generator to be able to start over from the start again.
+     */
+    override fun reset(){
+        angle = 0.0
+    }
+
+    /**
+     * Setup required before generating a frame. Must be called at least once before calculateData.
+     */
+    override fun setup(freqOfTone: Float, sampleRate: Int) {
+        val samplingInterval = sampleRate / freqOfTone
+        angleStep = PI / samplingInterval
+    }
+
+    private fun incrementAngle(
+        angle: Double,
+        angleStep: Double
+    ): Double {
+        return (angle + angleStep) % (2*Math.PI)
+    }
+
+    override fun calculateData(index: Int, amplitude: Int): Byte {
+        angle = incrementAngle(angle, angleStep)
+        return calculateData(angle, amplitude)
+    }
+
+    protected abstract fun calculateData(angle: Double, amplitude: Int): Byte;
+
+}

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SineWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SineWaveGenerator.kt
@@ -10,12 +10,6 @@ import kotlin.math.sin
  *
  * @see <a href="https://en.wikipedia.org/wiki/Sine_wave">Wikipedia</a>
  */
-object SineWaveGenerator : WaveByteArrayGenerator {
-
-    override fun calculateData(index: Int, samplingInterval: Float, amplitude: Int): Byte {
-        val angle: Double = (Math.PI * index) / samplingInterval
-        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
-    }
-
-    private fun waveFunction(angle: Double): Double = sin(angle)
+object SineWaveGenerator : WaveByteArrayGenerator() {
+    override fun waveFunction(angle: Double): Double = sin(angle)
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SineWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SineWaveGenerator.kt
@@ -10,6 +10,11 @@ import kotlin.math.sin
  *
  * @see <a href="https://en.wikipedia.org/wiki/Sine_wave">Wikipedia</a>
  */
-object SineWaveGenerator : WaveByteArrayGenerator() {
-    override fun waveFunction(angle: Double): Double = sin(angle)
+object SineWaveGenerator : AngleBaseWaveGenerator() {
+
+    override fun calculateData(angle: Double, amplitude: Int): Byte {
+        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
+    }
+
+    private fun waveFunction(angle: Double): Double = sin(angle)
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SquareWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SquareWaveGenerator.kt
@@ -11,12 +11,6 @@ import kotlin.math.sin
  * @see <a
  *     href="https://en.wikipedia.org/wiki/Square_wave">Wikipedia</a>
  */
-object SquareWaveGenerator : WaveByteArrayGenerator {
-
-    override fun calculateData(index: Int, samplingInterval: Float, amplitude: Int): Byte {
-        val angle: Double = (Math.PI * index) / samplingInterval
-        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
-    }
-
-    private fun waveFunction(angle: Double): Double = sign(sin(angle))
+object SquareWaveGenerator : WaveByteArrayGenerator() {
+    override fun waveFunction(angle: Double): Double = sign(sin(angle))
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SquareWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/SquareWaveGenerator.kt
@@ -11,6 +11,11 @@ import kotlin.math.sin
  * @see <a
  *     href="https://en.wikipedia.org/wiki/Square_wave">Wikipedia</a>
  */
-object SquareWaveGenerator : WaveByteArrayGenerator() {
-    override fun waveFunction(angle: Double): Double = sign(sin(angle))
+object SquareWaveGenerator : AngleBaseWaveGenerator() {
+
+    override fun calculateData(angle: Double, amplitude: Int): Byte {
+        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
+    }
+
+    private fun waveFunction(angle: Double): Double = sign(sin(angle))
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/TriangleWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/TriangleWaveGenerator.kt
@@ -11,12 +11,6 @@ import kotlin.math.sin
  * @see <a
  *     href="https://en.wikipedia.org/wiki/Triangle_wave">Wikipedia</a>
  */
-object TriangleWaveGenerator : WaveByteArrayGenerator {
-
-    override fun calculateData(index: Int, samplingInterval: Float, amplitude: Int): Byte {
-        val angle: Double = (Math.PI * index) / samplingInterval
-        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
-    }
-
-    private fun waveFunction(angle: Double): Double = asin(sin(angle))
+object TriangleWaveGenerator : WaveByteArrayGenerator(){
+    override fun waveFunction(angle: Double): Double = asin(sin(angle))
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/TriangleWaveGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/TriangleWaveGenerator.kt
@@ -11,6 +11,11 @@ import kotlin.math.sin
  * @see <a
  *     href="https://en.wikipedia.org/wiki/Triangle_wave">Wikipedia</a>
  */
-object TriangleWaveGenerator : WaveByteArrayGenerator(){
-    override fun waveFunction(angle: Double): Double = asin(sin(angle))
+object TriangleWaveGenerator : AngleBaseWaveGenerator(){
+
+    override fun calculateData(angle: Double, amplitude: Int): Byte {
+        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
+    }
+
+    private fun waveFunction(angle: Double): Double = asin(sin(angle))
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/WaveByteArrayGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/WaveByteArrayGenerator.kt
@@ -1,12 +1,17 @@
 package com.github.nisrulz.zentone.wave_generators
 
+import android.util.Log
 import com.github.nisrulz.zentone.DEFAULT_AMPLITUDE
 import com.github.nisrulz.zentone.DEFAULT_FREQUENCY_HZ
 import com.github.nisrulz.zentone.DEFAULT_SAMPLE_RATE
 import com.github.nisrulz.zentone.internal.minBufferSize
+import kotlin.math.PI
+import kotlin.math.abs
+import kotlin.math.sin
 
-interface WaveByteArrayGenerator {
+abstract class WaveByteArrayGenerator {
 
+    private var angle:Double = 0.0
     /**
      * Generate byte data for tone
      *
@@ -18,17 +23,34 @@ interface WaveByteArrayGenerator {
         freqOfTone: Float = DEFAULT_FREQUENCY_HZ,
         sampleRate: Int = DEFAULT_SAMPLE_RATE
     ): ByteArray {
-        val bufferSize = minBufferSize(sampleRate)
         val samplingInterval = sampleRate / freqOfTone
+        val angleStep = PI / samplingInterval
+        val bufferSize = minBufferSize(sampleRate)
 
         val generatedSnd = ByteArray(bufferSize)
 
         generatedSnd.indices.forEach { i ->
-            generatedSnd[i] = calculateData(i, samplingInterval, DEFAULT_AMPLITUDE)
+            angle = incrementAngle(angle, angleStep)
+            generatedSnd[i] = calculateData(angle, DEFAULT_AMPLITUDE)
         }
 
         return generatedSnd
     }
 
-    fun calculateData(index: Int, samplingInterval: Float, amplitude: Int): Byte
+    fun reset(){
+        angle = 0.0
+    }
+
+    fun incrementAngle(
+        angle: Double,
+        angleStep: Double
+    ): Double {
+        return (angle + angleStep) % (2*Math.PI)
+    }
+
+    private fun calculateData(angle: Double, amplitude: Int): Byte {
+        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
+    }
+
+    protected abstract fun waveFunction(angle: Double): Double;
 }

--- a/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/WaveByteArrayGenerator.kt
+++ b/zentone/src/main/java/com/github/nisrulz/zentone/wave_generators/WaveByteArrayGenerator.kt
@@ -1,17 +1,12 @@
 package com.github.nisrulz.zentone.wave_generators
 
-import android.util.Log
 import com.github.nisrulz.zentone.DEFAULT_AMPLITUDE
 import com.github.nisrulz.zentone.DEFAULT_FREQUENCY_HZ
 import com.github.nisrulz.zentone.DEFAULT_SAMPLE_RATE
 import com.github.nisrulz.zentone.internal.minBufferSize
-import kotlin.math.PI
-import kotlin.math.abs
-import kotlin.math.sin
 
-abstract class WaveByteArrayGenerator {
+interface WaveByteArrayGenerator {
 
-    private var angle:Double = 0.0
     /**
      * Generate byte data for tone
      *
@@ -23,34 +18,19 @@ abstract class WaveByteArrayGenerator {
         freqOfTone: Float = DEFAULT_FREQUENCY_HZ,
         sampleRate: Int = DEFAULT_SAMPLE_RATE
     ): ByteArray {
-        val samplingInterval = sampleRate / freqOfTone
-        val angleStep = PI / samplingInterval
+        setup(freqOfTone, sampleRate)
         val bufferSize = minBufferSize(sampleRate)
 
         val generatedSnd = ByteArray(bufferSize)
 
         generatedSnd.indices.forEach { i ->
-            angle = incrementAngle(angle, angleStep)
-            generatedSnd[i] = calculateData(angle, DEFAULT_AMPLITUDE)
+            generatedSnd[i] = calculateData(i, DEFAULT_AMPLITUDE)
         }
 
         return generatedSnd
     }
 
-    fun reset(){
-        angle = 0.0
-    }
-
-    fun incrementAngle(
-        angle: Double,
-        angleStep: Double
-    ): Double {
-        return (angle + angleStep) % (2*Math.PI)
-    }
-
-    private fun calculateData(angle: Double, amplitude: Int): Byte {
-        return (amplitude * waveFunction(angle) * Byte.MAX_VALUE).toInt().toByte()
-    }
-
-    protected abstract fun waveFunction(angle: Double): Double;
+    fun calculateData(index: Int, amplitude: Int): Byte
+    fun reset()
+    fun setup(freqOfTone: Float, sampleRate: Int)
 }


### PR DESCRIPTION
* Simplified wave generators
* Removed ticks by generating a new frame for each loop and keeping track of angle creep between frames.

## Summary

For every frame generated there was a discontinuity due to the last sample in the frame not being close to zero and the beginning of the frame.

To solve this now a new frame is generated for each loop and the angle drift is kept between frames to start the next frame at the correct level.

Also added an API to change the frequency without stopping/starting as that can crash the lib if start is triggered before the generation loop is actually stopped.

This is not an really clean pull request but please review and if you want me to split it up I can do so when fixing any issues. It is also my first bit of Kotlin code so happy for any pointers on bad solutions.

Also adjusted ident size to the one actually used in the files.

## How It Was Tested

Tested with and db/frequency app to see that the generated frequency was correct.

## Screenshot/Gif

No visible changes.